### PR TITLE
Create CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+### [0.2.2](https://www.github.com/google-github-actions/get-secretmanager-secrets/compare/v0.2.1...v0.2.2) (2021-03-05)
+
+
+### Bug Fixes
+
+* Added support for masking multiline secrets ([#9](https://www.github.com/google-github-actions/get-secretmanager-secrets/issues/9)) ([#10](https://www.github.com/google-github-actions/get-secretmanager-secrets/issues/10)) ([7a6a940](https://www.github.com/google-github-actions/get-secretmanager-secrets/commit/7a6a9404f3ef177ec8b310c95a51b8bee20bd09f))
+
+### [0.2.1](https://www.github.com/google-github-actions/get-secretmanager-secrets/compare/v0.2.0...v0.2.1) (2020-11-14)
+
+
+### Bug Fixes
+
+* update action desc ([#6](https://www.github.com/google-github-actions/get-secretmanager-secrets/issues/6)) ([57c14ff](https://www.github.com/google-github-actions/get-secretmanager-secrets/commit/57c14fff8763c66b8704d8035add5d46e3087e02))
+
+## [0.2.0](https://www.github.com/google-github-actions/get-secretmanager-secrets/compare/v0.1.0...v0.2.0) (2020-11-13)
+
+
+### ⚠ BREAKING CHANGES
+
+* transfer secretmanager action (#1)
+
+### Features
+
+* transfer secretmanager action ([#1](https://www.github.com/google-github-actions/get-secretmanager-secrets/issues/1)) ([081d1ad](https://www.github.com/google-github-actions/get-secretmanager-secrets/commit/081d1add35abdb1374fbcb92291f0c2c875f0720))


### PR DESCRIPTION
# Changelog### [0.2.2](https://www.github.com/google-github-actions/get-secretmanager-secrets/compare/v0.2.1...v0.2.2) (2021-03-05)### Bug Fixes* Added support for masking multiline secrets ([#9](https://www.github.com/google-github-actions/get-secretmanager-secrets/issues/9)) ([#10](https://www.github.com/google-github-actions/get-secretmanager-secrets/issues/10)) ([7a6a940](https://www.github.com/google-github-actions/get-secretmanager-secrets/commit/7a6a9404f3ef177ec8b310c95a51b8bee20bd09f))### [0.2.1](https://www.github.com/google-github-actions/get-secretmanager-secrets/compare/v0.2.0...v0.2.1) (2020-11-14)### Bug Fixes* update action desc ([#6](https://www.github.com/google-github-actions/get-secretmanager-secrets/issues/6)) ([57c14ff](https://www.github.com/google-github-actions/get-secretmanager-secrets/commit/57c14fff8763c66b8704d8035add5d46e3087e02))## [0.2.0](https://www.github.com/google-github-actions/get-secretmanager-secrets/compare/v0.1.0...v0.2.0) (2020-11-13)### ⚠ BREAKING CHANGES* transfer secretmanager action (#1)### Features* transfer secretmanager action ([#1](https://www.github.com/google-github-actions/get-secretmanager-secrets/issues/1)) ([081d1ad](https://www.github.com/google-github-actions/get-secretmanager-secrets/commit/081d1add35abdb1374fbcb92291f0c2c875f0720))